### PR TITLE
Issue36

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -33,5 +33,7 @@ tar -zxvf squashfs4.3.tar.gz
 # Patch, build, and install the source
 cd squashfs4.3
 patch -p0 < ../patches/patch0.txt
+# Issue #36
+patch -p0 < ../patches/patch1.txt
 cd squashfs-tools
 make && $SUDO make install

--- a/patches/patch1.txt
+++ b/patches/patch1.txt
@@ -1,0 +1,23 @@
+diff --strip-trailing-cr -NBbaur squashfs-tools/error.h squashfs-tools-patched/error.h
+--- squashfs-tools/error.h	2022-01-13 13:02:42.162534509 -0500
++++ squashfs-tools-patched/error.h	2022-01-13 13:03:10.842309065 -0500
+@@ -31,7 +31,7 @@
+ extern void progressbar_info(char *fmt, ...);
+ 
+ // CJH: Updated so that TRACE prints if -verbose is specified on the command line
+-int verbose;
++extern int verbose;
+ //#ifdef SQUASHFS_TRACE
+ #define TRACE(s, args...) \
+ 		do { \
+diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patched/unsquashfs.c
+--- squashfs-tools/unsquashfs.c	2022-01-13 13:02:42.182534352 -0500
++++ squashfs-tools-patched/unsquashfs.c	2022-01-13 13:03:18.406249609 -0500
+@@ -43,6 +43,7 @@
+ struct queue *to_reader, *to_inflate, *to_writer, *from_writer;
+ pthread_t *thread, *inflator_thread;
+ pthread_mutex_t	fragment_mutex;
++int verbose;
+ 
+ /* user options that control parallelisation */
+ //int processors = -1;


### PR DESCRIPTION
This is a tiny patch that fixes https://github.com/devttys0/sasquatch/issues/36 with a code change

I understand that it's possible to use CFLAGS to make newer versions of gcc accept the code "as-is" but in my opinion it's better to address it this way by moving the declaration of verbose into a single .c and accessing it as an extern elsewhere.

Because verbose is only accessed directly in unsquash.c (by the command-line flag parsing code) I put it there, it seemed the most logical

For whatever reason I wasn't able to create a clean patch to your patch, so rather than replace the entire patch0.txt with the changes, I added a patch1.txt. I assume you'll want to coalesce these into one if you decide to accept this

I didn't do extensive testing on the change but it builds and functions as expected both with and without the -trace flag. I tested by building (obviously), extracting a few squashfs filesystems I had laying around and making sure the trace output showed up and there weren't any runtime symbol resolution errors

Thanks for all your work on binwalk and embedded RE in general!