### PR TITLE
Fix fcomon and misleading indentation error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,4 +34,4 @@ tar -zxvf squashfs4.3.tar.gz
 cd squashfs4.3
 patch -p0 < ../patches/patch0.txt
 cd squashfs-tools
-make && $SUDO make install
+CFLAGS="-fcommon -Wno-misleading-indentation" make && $SUDO make install


### PR DESCRIPTION
Tested with gcc version 11.2.0 (Debian 11.2.0-10) on kali