### PR TITLE
Make build GCC v10 compatible

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,4 +34,4 @@ tar -zxvf squashfs4.3.tar.gz
 cd squashfs4.3
 patch -p0 < ../patches/patch0.txt
 cd squashfs-tools
-make && $SUDO make install
+make EXTRA_CFLAGS=-fcommon && $SUDO make install


### PR DESCRIPTION
GCC version 10 changes the default behaviour from -fcommon to
-fno-common which results in a linker error.

Signed-off-by: Sven Schwermer <sven@svenschwermer.de>